### PR TITLE
Adding Docker Capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Usage:
 #   docker build -t mad .                 # Build the docker Image
 #   docker run -d mad startWalker.py -os  # Launch Walker 
-#   docker run -d mad startWalker.py -os  # Launch Screenshot Processing
-#   docker run -d mad madmin.py           # Launch MAdmin
+#   docker run -d mad startWalker.py -oo  # Launch Screenshot Processing
+#   docker run -d mad startWalker.py -wm  # Launch MAdmin
 
 FROM python:2.7-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,5 @@ COPY requirements.txt /usr/src/app/
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-# RUN apt-get install libgtk2.0-dev -y
-
 # Copy everything to the working directory (Python files, templates, config) in one go.
 COPY . /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Basic docker image for Map-a-Droid
 # Usage:
-#   docker build -t mad                   # Build the docker Image
+#   docker build -t mad .                 # Build the docker Image
 #   docker run -d mad startWalker.py -os  # Launch Walker 
 #   docker run -d mad startWalker.py -os  # Launch Screenshot Processing
 #   docker run -d mad madmin.py           # Launch MAdmin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Basic docker image for Map-a-Droid
+# Usage:
+#   docker build -t MAD                   # Build the docker Image
+#   docker run -d MAD startWalker.py -os  # Launch Walker 
+#   docker run -d MAD startWalker.py -os  # Launch Screenshot Processing
+#   docker run -d MAD madmin.py           # Launch MAdmin
+
+FROM python:2.7-slim
+
+# Default port the webserver runs on
+EXPOSE 5000
+
+# Working directory for the application
+WORKDIR /usr/src/app
+
+# Set Entrypoint with hard-coded options
+ENTRYPOINT ["python"]
+CMD ["./startWalker.py"] 
+
+# Install required system packages
+RUN apt-get update && apt-get install -y --no-install-recommends libgeos-dev build-essential
+RUN apt-get update && apt-get -y install libglib2.0-0
+RUN apt-get -y install tk
+RUN apt-get update
+
+COPY requirements.txt /usr/src/app/
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# RUN apt-get install libgtk2.0-dev -y
+
+# Copy everything to the working directory (Python files, templates, config) in one go.
+COPY . /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Basic docker image for Map-a-Droid
 # Usage:
-#   docker build -t MAD                   # Build the docker Image
-#   docker run -d MAD startWalker.py -os  # Launch Walker 
-#   docker run -d MAD startWalker.py -os  # Launch Screenshot Processing
-#   docker run -d MAD madmin.py           # Launch MAdmin
+#   docker build -t mad                   # Build the docker Image
+#   docker run -d mad startWalker.py -os  # Launch Walker 
+#   docker run -d mad startWalker.py -os  # Launch Screenshot Processing
+#   docker run -d mad madmin.py           # Launch MAdmin
 
 FROM python:2.7-slim
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ imutils
 configargparse
 image
 scikit-image
-mysql-connector-python-rf
+mysql-connector-python
 twisted
 gpxdata
 flask


### PR DESCRIPTION
Adding a docker file for people willing to run Map-a-Droid in a Docker environnement.

Also updating mysql-connector-python-rf to mysql-connector-python as -rf is not required (confirmed with Grennith) and didn't compile under docker.

Docker image has been tested and building fine on my system.

downloadCoords.py, downloadGymImages.py and startWalker.py tested and working fine on my system.
