### PR TITLE
Fix null issue with sponsor in downloadGymImage

### DIFF
--- a/db/monocle.py
+++ b/db/monocle.py
@@ -744,7 +744,7 @@ class MonocleWrapper:
 
         if park != "unknown":
             gymJson['park'] = park
-        if sponsor is not 0:
+        if sponsor is not 0 and sponsor is not None:
             gymJson['sponsor'] = sponsor
 
         log.debug(gymJson)


### PR DESCRIPTION
## Description
Because the possibility of null being in the sponsor db field wasn't addressed, `sponsor: null` got put into the `gym_info.json` file, which lead to broken webhooks because `None` would get converted into a string and sent.

## How Has This Been Tested?
Ran locally

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Where appropriate examples are updated such as config.ini.example
- [ ] I have updated the documentation accordingly.