### PR TITLE
MADmin Ui rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ venv/
 *.calc
 *.position
 geofence.txt
+.vs

--- a/db/rm.py
+++ b/db/rm.py
@@ -838,7 +838,6 @@ class RmWrapper:
         cursor.close()
         connection.close()
         with io.open('gym_info.json', 'w', encoding='UTF-8') as outfile:
-            #outfile.write(json.dumps(gyminfo, indent=4, sort_keys=True))
             outfile.write(unicode(json.dumps(gyminfo, indent=4, sort_keys=True)))
         print('Finished...')
         return True

--- a/db/rm.py
+++ b/db/rm.py
@@ -838,7 +838,8 @@ class RmWrapper:
         cursor.close()
         connection.close()
         with io.open('gym_info.json', 'w', encoding='UTF-8') as outfile:
-            outfile.write(json.dumps(gyminfo, indent=4, sort_keys=True))
+            #outfile.write(json.dumps(gyminfo, indent=4, sort_keys=True))
+            outfile.write(unicode(json.dumps(gyminfo, indent=4, sort_keys=True)))
         print('Finished...')
         return True
         

--- a/madmin.py
+++ b/madmin.py
@@ -58,7 +58,7 @@ def root():
 
 @app.route('/raids', methods=['GET'])
 def raids():
-    return render_template('raids.html', sort = str(args.madmin_sort), responsive = str(args.madmin_noresponsive).lower(), title = "show Gym Matching")
+    return render_template('raids.html', sort = str(args.madmin_sort), responsive = str(args.madmin_noresponsive).lower(), title = "show Raid Matching")
     
 @app.route('/gyms', methods=['GET'])
 def gyms():
@@ -525,7 +525,6 @@ def creation_date(path_to_file):
             return stat.st_mtime
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0')
-    #app.run()
+    app.run()
     #host='0.0.0.0', port=int(args.madmin_port), threaded=False)
 

--- a/madmin.py
+++ b/madmin.py
@@ -374,7 +374,8 @@ def get_unknows():
     unk = []
     for file in glob.glob("www_hash/unkgym_*.jpg"):
         unkfile = re.search('unkgym_(-?\d+\.?\d+)_(-?\d+\.?\d+)_((?s).*)\.jpg', file)
-        creationdate = datetime.datetime.fromtimestamp(creation_date(file)).strftime('%Y-%m-%d %H:%M:%S')
+        #creationdate = datetime.datetime.fromtimestamp(creation_date(file)).strftime('%Y-%m-%d %H:%M:%S')
+        creationdate = datetime.datetime.fromtimestamp(creation_date(file)).isoformat()
         lat = (unkfile.group(1))
         lon = (unkfile.group(2))
         hashvalue = (unkfile.group(3))

--- a/madmin.py
+++ b/madmin.py
@@ -526,6 +526,7 @@ def creation_date(path_to_file):
             return stat.st_mtime
 
 if __name__ == "__main__":
-    app.run()
+    app.run(host='0.0.0.0')
+    #app.run()
     #host='0.0.0.0', port=int(args.madmin_port), threaded=False)
 

--- a/madmin.py
+++ b/madmin.py
@@ -374,8 +374,7 @@ def get_unknows():
     unk = []
     for file in glob.glob("www_hash/unkgym_*.jpg"):
         unkfile = re.search('unkgym_(-?\d+\.?\d+)_(-?\d+\.?\d+)_((?s).*)\.jpg', file)
-        #creationdate = datetime.datetime.fromtimestamp(creation_date(file)).strftime('%Y-%m-%d %H:%M:%S')
-        creationdate = datetime.datetime.fromtimestamp(creation_date(file)).isoformat()
+        creationdate = datetime.datetime.fromtimestamp(creation_date(file)).strftime('%Y-%m-%d %H:%M:%S')
         lat = (unkfile.group(1))
         lon = (unkfile.group(2))
         hashvalue = (unkfile.group(3))

--- a/madmin.py
+++ b/madmin.py
@@ -50,7 +50,7 @@ def after_request(response):
 
 @app.route('/screens', methods=['GET'])
 def screens():
-    return render_template('screens.html', responsive = str(args.madmin_noresponsive).lower())
+    return render_template('screens.html', responsive = str(args.madmin_noresponsive).lower(), title = "show success Screens")
 
 @app.route('/', methods=['GET'])
 def root():
@@ -58,19 +58,19 @@ def root():
 
 @app.route('/raids', methods=['GET'])
 def raids():
-    return render_template('raids.html', sort = str(args.madmin_sort), responsive = str(args.madmin_noresponsive).lower())
+    return render_template('raids.html', sort = str(args.madmin_sort), responsive = str(args.madmin_noresponsive).lower(), title = "show Gym Matching")
     
 @app.route('/gyms', methods=['GET'])
 def gyms():
-    return render_template('gyms.html', sort = args.madmin_sort, responsive = str(args.madmin_noresponsive).lower()) 
+    return render_template('gyms.html', sort = str(args.madmin_sort), responsive = str(args.madmin_noresponsive).lower(), title = "show Gym Matching") 
 
 @app.route('/unknown', methods=['GET'])
 def unknown():
-    return render_template('unknown.html', responsive = str(args.madmin_noresponsive).lower()) 
+    return render_template('unknown.html', responsive = str(args.madmin_noresponsive).lower(), title = "show unknown Gym") 
 
 @app.route('/map', methods=['GET'])
 def map():
-    return render_template('map.html')
+    return render_template('map.html', title = "Map")
 
 @app.route("/submit_hash")
 def submit_hash():
@@ -453,7 +453,7 @@ def match_unknows():
     hash = request.args.get('hash')
     lat = request.args.get('lat')
     lon = request.args.get('lon')
-    return render_template('match_unknown.html', hash = hash, lat = lat, lon = lon, responsive = str(args.madmin_noresponsive).lower())
+    return render_template('match_unknown.html', hash = hash, lat = lat, lon = lon, responsive = str(args.madmin_noresponsive).lower(), title = "match Unknown")
 
 @app.route('/modify_raid', methods=['GET'])
 def modify_raid():
@@ -462,21 +462,21 @@ def modify_raid():
     lon = request.args.get('lon')
     lvl = request.args.get('lvl')
     mon = request.args.get('mon')
-    return render_template('change_raid.html', hash = hash, lat = lat, lon = lon, lvl = lvl, mon = mon, responsive = str(args.madmin_noresponsive).lower())
+    return render_template('change_raid.html', hash = hash, lat = lat, lon = lon, lvl = lvl, mon = mon, responsive = str(args.madmin_noresponsive).lower(), title = "change Raid")
 
 @app.route('/modify_gym', methods=['GET'])
 def modify_gym():
     hash = request.args.get('hash')
     lat = request.args.get('lat')
     lon = request.args.get('lon')
-    return render_template('change_gym.html', hash = hash, lat = lat, lon = lon, responsive = str(args.madmin_noresponsive).lower())
+    return render_template('change_gym.html', hash = hash, lat = lat, lon = lon, responsive = str(args.madmin_noresponsive).lower(), title = "change Gym")
 
 @app.route('/modify_mon', methods=['GET'])
 def modify_mon():
     hash = request.args.get('hash')
     gym = request.args.get('gym')
     lvl = request.args.get('lvl')
-    return render_template('change_mon.html', hash = hash, gym = gym, lvl = lvl, responsive = str(args.madmin_noresponsive).lower())
+    return render_template('change_mon.html', hash = hash, gym = gym, lvl = lvl, responsive = str(args.madmin_noresponsive).lower(), title = "change Mon")
 
 @app.route('/asset/<path:path>', methods=['GET'])
 def pushAssets(path):

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang ="en">
+<head>
+    <meta charset="utf-8">
+    {% if title %}
+    <title>MADmin - {{ title }}</title>
+    {% else %}
+    <title>MADmin</title>
+    {% endif %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.18/fh-3.1.4/r-2.2.2/datatables.min.css"/>
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
+    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
+    {% block header %}{% endblock %}
+    <style>
+        .responsive {
+            width: 100%;
+            height: auto;
+        }
+        .brandimg {
+            max-height: 20px;
+        }
+    </style>
+    
+    <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.18/fh-3.1.4/r-2.2.2/datatables.min.js"></script>
+    {% block scripts %}{% endblock %}
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed">
+        <div class="container-fluid">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="https://github.com/Grennith/Map-A-Droid">                    
+                    <img src="{{ url_for('static', filename='banner_small_web.png') }}" class="brandimg">
+                </a>
+                <a class="navbar-brand" href="/">MADmin</a>
+            </div>
+            <div id="navbar" class="navbar-collapse collapse">
+                <ul class="nav navbar-nav">
+                        <li id="navraids"><a href="/raids">Check Raids</a></li>
+                        <li id="navgyms"><a href="/gyms">Check Gyms</a></li>
+                        <li id="navunknown"><a href="/unknown">Check Unknown Gyms</a></li>
+                        <li id="navscreens"><a href="/screens">Processed Screens</a></li>
+                        <li id="navmap"><a href="/map">Map</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container" role="main">
+        {% block content %}{% endblock %}
+    </div>
+    
+    {% block bodyendscripts %}{% endblock %}
+</body>
+</html>

--- a/templates/change_gym.html
+++ b/templates/change_gym.html
@@ -32,7 +32,7 @@
                 {
                     "targets": [3],
                     "render": function (data, type, row) {
-                        return "<a href='modify_gym_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a>";
+                        return "<a href='modify_gym_hash?hash={{ hash }}&id=" + data + "'>Match to this Gym</a>";
                     }
                 }
             ],

--- a/templates/change_gym.html
+++ b/templates/change_gym.html
@@ -4,39 +4,63 @@
 {% endblock %}
 
 {% block scripts %}
-    <script>
-        $(document).ready(function () {
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_gym_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'dist', title: 'Distance' },
+                { data: 'id', title: 'Match' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function (data, type, row) {
+                        return data + "<br /><br />Gym-ID: " + row.id;
                     }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        responsive: {{ responsive }},
-                        "order": [[2, "asc"]],
-                        "autoWidth": true
-                    });
+                },
+                {
+                    "targets": [1],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
+                    }
+                },
+                {
+                    "targets": [3],
+                    "render": function (data, type, row) {
+                        return "<a href='modify_gym_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a>";
+                    }
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[2, "asc"]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+    $(document).ready(function () {
+
+        var displayResources = $('#show-data');
+
+        displayResources.text('Loading data ...');
+
+        $.ajax({
+            type: "GET",
+            url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Modify existing Gym</h2>
-    <h4><a href="/gyms">Back to Gyms</a></h4>
-    <div id="show-data"></div>
+<h2>Modify existing Gym</h2>
+<h4><a href="/gyms">Back to Gyms</a></h4>
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/change_gym.html
+++ b/templates/change_gym.html
@@ -4,6 +4,8 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+
 <script>
     function setGrid(tableGridHtmlId, gridData) {
         $(tableGridHtmlId).DataTable({

--- a/templates/change_gym.html
+++ b/templates/change_gym.html
@@ -1,62 +1,42 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - change Gym</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Modify existing Gym</h1>
-<h4><a href=/gyms>Back to Gyms</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script>
+        $(document).ready(function () {
 
-		  
-		  
-		  $(document).ready(function () {
+            var displayResources = $('#show-data');
 
-		   var displayResources = $('#show-data');
+            displayResources.text('Loading data ...');
 
-		   displayResources.text('Loading data ...');
+            $.ajax({
+                type: "GET",
+                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_gym_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_gym_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        responsive: {{ responsive }},
+                        "order": [[2, "asc"]],
+                        "autoWidth": true
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-			       responsive: {{ responsive }},
-			       "order": [[ 2, "asc" ]],
-			       "autoWidth": true
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Modify existing Gym</h2>
+    <h4><a href="/gyms">Back to Gyms</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/change_mon.html
+++ b/templates/change_mon.html
@@ -1,62 +1,42 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - change Mon</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Modify detecting Mon</h1>
-<h4><a href=/raids>Back to Raids</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script>
+        $(document).ready(function () {
 
-		  
-		  
-		  $(document).ready(function () {
+            var displayResources = $('#show-data');
 
-		   var displayResources = $('#show-data');
+            displayResources.text('Loading data ...');
 
-		   displayResources.text('Loading data ...');
+            $.ajax({
+                type: "GET",
+                url: "/get_mons",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>ID</th><th>Level</th><th>Pic</th><th>Match</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td>" + result[i].name + "</td><td>" + result[i].mon + "</td><td>" + result[i].lvl + "</td><td><img src='" + result[i].filename + "' width=100></td><td><a href='modify_raid_mon?hash={{ hash }}&mon=" + result[i].mon + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/get_mons",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>ID</th><th>Level</th><th>Pic</th><th>Match</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td>" + result[i].name + "</td><td>" + result[i].mon + "</td><td>" + result[i].lvl + "</td><td><img src='" + result[i].filename + "' width=100></td><td><a href='modify_raid_mon?hash={{ hash }}&mon=" + result[i].mon + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        responsive: {{ responsive }},
+                        "order": [[1, "asc"]],
+                        "autoWidth": true
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-			       responsive: {{ responsive }},
-			   "order": [[ 1, "asc" ]],
-			       "autoWidth": true
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Modify detecting Mon</h2>
+    <h4><a href="/raids">Back to Raids</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/change_mon.html
+++ b/templates/change_mon.html
@@ -4,39 +4,57 @@
 {% endblock %}
 
 {% block scripts %}
-    <script>
-        $(document).ready(function () {
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/get_mons",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>ID</th><th>Level</th><th>Pic</th><th>Match</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td>" + result[i].name + "</td><td>" + result[i].mon + "</td><td>" + result[i].lvl + "</td><td><img src='" + result[i].filename + "' width=100></td><td><a href='modify_raid_mon?hash={{ hash }}&mon=" + result[i].mon + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a> </td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'mon', title: 'ID' },
+                { data: 'lvl', title: 'Level' },
+                { data: 'filename', title: 'Pic' },
+                { data: 'mon', title: 'Match' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [3],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
                     }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        responsive: {{ responsive }},
-                        "order": [[1, "asc"]],
-                        "autoWidth": true
-                    });
+                },
+                {
+                    "targets": [4],
+                    "render": function (data, type, row) {
+                        return "<a href='modify_raid_mon?hash={{ hash }}&mon=" + result[i].mon + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a>";
+                    }
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[1, "asc"]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+
+    $(document).ready(function () {
+        $("#navraids").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/get_mons",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Modify detecting Mon</h2>
-    <h4><a href="/raids">Back to Raids</a></h4>
-    <div id="show-data"></div>
+<h2>Modify detecting Mon</h2>
+<h4><a href="/raids">Back to Raids</a></h4>
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/change_mon.html
+++ b/templates/change_mon.html
@@ -25,7 +25,7 @@
                 {
                     "targets": [4],
                     "render": function (data, type, row) {
-                        return "<a href='modify_raid_mon?hash={{ hash }}&mon=" + result[i].mon + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a>";
+                        return "<a href='modify_raid_mon?hash={{ hash }}&mon=" + data + "&gym={{ gym }}&lvl={{ lvl }}'>Match this </a>";
                     }
                 }
             ],

--- a/templates/change_mon.html
+++ b/templates/change_mon.html
@@ -4,6 +4,8 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+
 <script>
     function setGrid(tableGridHtmlId, gridData) {
         $(tableGridHtmlId).DataTable({

--- a/templates/change_raid.html
+++ b/templates/change_raid.html
@@ -1,62 +1,42 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - change Raid</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Modify existing Raid</h1>
-<h4><a href=/raids>Back to Raids</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script>
+        $(document).ready(function () {
 
-		  
-		  
-		  $(document).ready(function () {
+            var displayResources = $('#show-data');
 
-		   var displayResources = $('#show-data');
+            displayResources.text('Loading data ...');
 
-		   displayResources.text('Loading data ...');
+            $.ajax({
+                type: "GET",
+                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_raid_gym?hash={{ hash }}&id=" + result[i].id + "&mon={{ mon }}&lvl={{ lvl }}'>Match to this Gym</a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_raid_gym?hash={{ hash }}&id=" + result[i].id + "&mon={{ mon }}&lvl={{ lvl }}'>Match to this Gym</a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        responsive: {{ responsive }},
+                        "order": [[2, "asc"]],
+                        "autoWidth": true
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-			       responsive: {{ responsive }},
-			   "order": [[ 2, "asc" ]],
-			       "autoWidth": true
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Modify existing Raid</h2>
+    <h4><a href="/raids">Back to Raids</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/change_raid.html
+++ b/templates/change_raid.html
@@ -4,39 +4,61 @@
 {% endblock %}
 
 {% block scripts %}
-    <script>
-        $(document).ready(function () {
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td>" + result[i].name + "<br><br>Gym-ID: " + result[i].id + "</td><td><img src='" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='modify_raid_gym?hash={{ hash }}&id=" + result[i].id + "&mon={{ mon }}&lvl={{ lvl }}'>Match to this Gym</a> </td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'dist', title: 'Distance' },
+                { data: 'id', title: 'Match' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function (data, type, row) {
+                        return data + "<br /><br />Gym-ID: " + row.id;
                     }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        responsive: {{ responsive }},
-                        "order": [[2, "asc"]],
-                        "autoWidth": true
-                    });
+                },
+                {
+                    "targets": [1],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
+                    }
+                },
+                {
+                    "targets": [3],
+                    "render": function (data, type, row) {
+                        return "<a href='modify_raid_gym?hash={{ hash }}&id=" + data + "&mon={{ mon }}&lvl={{ lvl }}'>Match to this Gym</a>";
+                    }
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[2, "desc"]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+    $(document).ready(function () {
+        $("#navraids").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Modify existing Raid</h2>
-    <h4><a href="/raids">Back to Raids</a></h4>
-    <div id="show-data"></div>
+<h2>Modify existing Raid</h2>
+<h4><a href="/raids">Back to Raids</a></h4>
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/change_raid.html
+++ b/templates/change_raid.html
@@ -4,6 +4,8 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+
 <script>
     function setGrid(tableGridHtmlId, gridData) {
         $(tableGridHtmlId).DataTable({

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -4,45 +4,63 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-    <script>
-        $(document).ready(function () {
-            $("#navgyms").addClass("active");
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/get_gyms",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>Hash</th><th>Hashpic</th><th>Gympic</th><th>Matchcount</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td>" + result[i].name + "</td><td>" + result[i].hashvalue + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + result[i].count + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_gym?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Change Gym</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=gym&redirect=gyms'>Delete</a> </td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'hashvalue', title: 'Hash' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'gymimage', title: 'Gympic' },
+                { data: 'lon', title: 'Matchcount' },
+                { data: 'modify', title: 'Last Modify', type: 'date' },
+                { data: 'creation', title: 'Creation Date', type: 'date' },
+                { data: '', title: 'Actions' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [2, 3],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
                     }
-                    output += "</tbody></table>";
+                },
+                {
+                    "targets:": [7],
+                    "render": function (data, type, row) {
+                        var modifyGym = "<a href='/modify_gym?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Change Gym</a>";
+                        var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=gym&redirect=gyms'>Delete</a>";
 
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        drawCallback: function () {
-                            $("img.lazy").lazyload();
-                        },
-                        "order": [[{{ sort }}, "desc" ]],
-                        responsive: {{ responsive }},
-                        "autoWidth": true,
-                        columnDefs: [{ targets: [5, 6], type: 'date' }]
-                    });
+                        return modifyGym + "<br />" + deleteHash;
+                    }
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[{{ sort }}, "desc"]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+    $(document).ready(function () {
+        $("#navgyms").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/get_gyms",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Check saved Gyms</h2>
-    <div id="show-data"></div>
+<h2>Check saved Gyms</h2>
+<div id="show-data"></div>
 {% endblock %}

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -1,67 +1,49 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - show Gym Matching</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Check saved Gyms</h1>
-<h4><a href=/>Back to Menu</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
+    <script>
+        $(document).ready(function () {
+            $("#navgyms").addClass("active");
 
+            var displayResources = $('#show-data');
 
-		  $(document).ready(function () {
+            displayResources.text('Loading data ...');
 
-		   var displayResources = $('#show-data');
+            $.ajax({
+                type: "GET",
+                url: "/get_gyms",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>Hash</th><th>Hashpic</th><th>Gympic</th><th>Matchcount</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td>" + result[i].name + "</td><td>" + result[i].hashvalue + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + result[i].count + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_gym?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Change Gym</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=gym&redirect=gyms'>Delete</a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   displayResources.text('Loading data ...');
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        drawCallback: function () {
+                            $("img.lazy").lazyload();
+                        },
+                        "order": [[{{ sort }}, "desc" ]],
+                        responsive: {{ responsive }},
+                        "autoWidth": true,
+                        columnDefs: [{ targets: [5, 6], type: 'date' }]
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/get_gyms",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>Hash</th><th>Hashpic</th><th>Gympic</th><th>Matchcount</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td>" + result[i].name + "</td><td>" + result[i].hashvalue + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + result[i].count + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_gym?hash=" + result[i].hashvalue + "&lat=" + result[i].lat +"&lon=" + result[i].lon + "'>Change Gym</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=gym&redirect=gyms'>Delete</a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
-
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-                   drawCallback: function(){
-                       $("img.lazy").lazyload();
-                   },
-		           "order": [[ {{ sort }}, "desc" ]],
-			       responsive: {{ responsive }},
-			       "autoWidth": true,
-			       columnDefs: [{ targets: [5, 6], type: 'date'}]
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Check saved Gyms</h2>
+    <h4><a href="/">Back to Menu</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -18,9 +18,7 @@
                 { data: 'count', title: 'Matchcount' },
                 { data: 'modify', title: 'Last Modify', type: 'date' },
                 { data: 'creation', title: 'Creation Date', type: 'date' },
-                { data: '', title: 'Actions' },
-                { data: 'lat', title: ''},
-                { data: 'lon', title: ''}
+                { data: '', title: 'Actions' }
             ],
             "columnDefs": [
                 {
@@ -32,16 +30,11 @@
                 {
                     "targets:": [7],
                     "render": function (data, type, row) {
-                        console.log(row);
                         var modifyGym = "<a href='/modify_gym?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Change Gym</a>";
                         var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=gym&redirect=gyms'>Delete</a>";
 
                         return modifyGym + "<br />" + deleteHash;
                     }
-                },
-                {
-                    "targets": [8,9],
-                    "visible": false
                 }
             ],
             "drawCallback": function () {
@@ -60,6 +53,7 @@
             type: "GET",
             url: "/get_gyms",
             success: function (result) {
+                console.log(result);
                 setGrid('#show-data', result);
             }
         });

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -18,10 +18,6 @@
                 { data: 'count', title: 'Matchcount' },
                 { data: 'modify', title: 'Last Modify', type: 'date' },
                 { data: 'creation', title: 'Creation Date', type: 'date' },
-                { data: 'id', title: ''},
-                { data: 'lat', title: ''},
-                { data: 'lon', title: ''},                
-                { data: 'description', title: ''},
                 { data: '', title: 'Actions' }
             ],
             "columnDefs": [
@@ -32,11 +28,7 @@
                     }
                 },
                 {
-                    "targets": [7, 8, 9, 10],
-                    "visible": false
-                },
-                {
-                    "targets:": [11],
+                    "targets": [7],
                     "render": function (data, type, row) {
                         var modifyGym = "<a href='/modify_gym?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Change Gym</a>";
                         var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=gym&redirect=gyms'>Delete</a>";

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -18,6 +18,10 @@
                 { data: 'count', title: 'Matchcount' },
                 { data: 'modify', title: 'Last Modify', type: 'date' },
                 { data: 'creation', title: 'Creation Date', type: 'date' },
+                { data: 'id', title: ''},
+                { data: 'lat', title: ''},
+                { data: 'lon', title: ''},                
+                { data: 'description', title: ''},
                 { data: '', title: 'Actions' }
             ],
             "columnDefs": [
@@ -28,7 +32,11 @@
                     }
                 },
                 {
-                    "targets:": [7],
+                    "targets": [7, 8, 9, 10],
+                    "visible": false
+                },
+                {
+                    "targets:": [11],
                     "render": function (data, type, row) {
                         var modifyGym = "<a href='/modify_gym?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Change Gym</a>";
                         var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=gym&redirect=gyms'>Delete</a>";

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -32,6 +32,7 @@
                 {
                     "targets:": [7],
                     "render": function (data, type, row) {
+                        console.log(row);
                         var modifyGym = "<a href='/modify_gym?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Change Gym</a>";
                         var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=gym&redirect=gyms'>Delete</a>";
 

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -61,10 +61,6 @@
 {% endblock %}
 
 {% block content %}
-{% if title %}
-<h2>{{ title }}</h2>
-{% else %}
 <h2>Check saved Gyms</h2>
-{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -15,10 +15,12 @@
                 { data: 'hashvalue', title: 'Hash' },
                 { data: 'filename', title: 'Hashpic' },
                 { data: 'gymimage', title: 'Gympic' },
-                { data: 'lon', title: 'Matchcount' },
+                { data: 'count', title: 'Matchcount' },
                 { data: 'modify', title: 'Last Modify', type: 'date' },
                 { data: 'creation', title: 'Creation Date', type: 'date' },
-                { data: '', title: 'Actions' }
+                { data: '', title: 'Actions' },
+                { data: 'lat', title: ''},
+                { data: 'lon', title: ''}
             ],
             "columnDefs": [
                 {
@@ -35,6 +37,10 @@
 
                         return modifyGym + "<br />" + deleteHash;
                     }
+                },
+                {
+                    "targets": [8,9],
+                    "visible": false
                 }
             ],
             "drawCallback": function () {

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -44,6 +44,5 @@
 
 {% block content %}
     <h2>Check saved Gyms</h2>
-    <h4><a href="/">Back to Menu</a></h4>
     <div id="show-data"></div>
 {% endblock %}

--- a/templates/gyms.html
+++ b/templates/gyms.html
@@ -61,6 +61,10 @@
 {% endblock %}
 
 {% block content %}
+{% if title %}
+<h2>{{ title }}</h2>
+{% else %}
 <h2>Check saved Gyms</h2>
-<div id="show-data"></div>
+{% endif %}
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,30 +1,16 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADmin</title>
- <meta name="viewport" content="width=device-width, initial-scale=1">
- <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
- <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
- <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
- <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
- <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- <style>
- .responsive {
-     width: 100%;
-     height: auto;
- }
- </style>
- </head>
-<body>
-<img src={{ url_for('static', filename='banner_small_web.png') }} class="responsive">
-<center>
-<h1>MADmin</h1>
-	<h3><a href=/raids>Check Raids</a></h3>
-	<h3><a href=/gyms>Check Gyms</a></h3>
-	<h3><a href=/unknown>Check Unknown Gyms</a></h3>
-	<h3><a href=/screens>Processed Screens</a></h3>
-	<h3><a href=/map>Map</a></h3>
-</body>
-</html>
+﻿{% extends "base.html" %}
+
+{% block header %}
+{% endblock %}
+
+{% block scripts %}
+{% endblock %}
+
+{% block content %}
+    <h2>MADmin</h2>
+    <h3><a href="/raids">Check Raids</a></h3>
+    <h3><a href="/gyms">Check Gyms</a></h3>
+    <h3><a href="/unknown">Check Unknown Gyms</a></h3>
+    <h3><a href="/screens">Processed Screens</a></h3>
+    <h3><a href="/map">Map</a></h3>
+{% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,109 +1,95 @@
-<html
-<head>
-	<meta charset="utf-8">
-	<title>MADMIN - Map</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-	<link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-	<link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin=""/>
-	<style>
-		#mapouter {
-			padding: 0px 30px;
-			width: auto;
-			height: 800px;
-			max-height: 800px;
-		}
+﻿{% extends "base.html" %}
 
-		#map {
-			width: 100%;
-			height: 100%;
-			border: 1px solid #333;
-		}
-	</style>
-</head>
-<body>
-	<center><h1>MAD Map</h1>
-	<h4><a href=/>Back to Menu</a></h4></center>
-	<div id="mapouter">
-		<div id="map"></div>
-	</div>
-	<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-	<script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet-src.js"></script>
-	<script>
-	function convertToLonLat(coords) {
-		lonlat = []
-		$.each(coords, function(k, v) {
-			lonlat.push([v[1], v[0]]);
-		})
-		return lonlat;
-	}
+{% block header %}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin="" />
+    <style>
+        #mapouter {
+            padding: 0px 30px;
+            width: auto;
+            height: 800px;
+            max-height: 800px;
+        }
 
-	$(document).ready(function () {
-		var map = L.map('map').setView([0, 0], 13);
-		var prevLoc = [0, 0];
-		var marker = L.marker([0, 0], { title: "Bot position"}).addTo(map);
+        #map {
+            width: 100%;
+            height: 100%;
+            border: 1px solid #333;
+        }
+    </style>
+{% endblock %}
 
-		L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
-			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
-		}).addTo(map);
+{% block scripts %}
+    <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet-src.js"></script>
+    <script>
+        function convertToLonLat(coords) {
+            lonlat = []
+            $.each(coords, function (k, v) {
+                lonlat.push([v[1], v[0]]);
+            })
+            return lonlat;
+        }
 
-		$.getJSON({
-			url: "/get_route",
-			success: function(result) {
-				$.each(result, function(k, v) {
-					L.circle(v, {
-						radius: 490,
-						color: "#9C3744",
-						fillColor: "#F4556A",
-						fillOpacity: 0.5,
-						weight: 1,
-						opacity: 0.2,
-						fillOpacity: 0.1
-					}).addTo(map);
-				});
+        $(document).ready(function () {
+            $("#navmap").addClass("active");
 
-				var geojson = {
-					"type": "LineString",
-					"coordinates": convertToLonLat(result)
-				};
+            var map = L.map('map').setView([0, 0], 13);
+            var prevLoc = [0, 0];
+            var marker = L.marker([0, 0], { title: "Bot position" }).addTo(map);
 
-				L.geoJSON(geojson).addTo(map);
-				marker.setLatLng(result[0]);
-				map.setView(result[0], map.getZoom());
-			}
-		});
+            L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+            }).addTo(map);
 
-		$.getJSON({
-			url: "/get_gymcoords",
-			success: function(result) {
-				$.each(result, function(k, v) {
-					L.circle([v['lat'], v['lon']], {
-						radius: 25,
-						color: "#666",
-						fillColor: "#ff925b",
-						weight: 1,
-						opacity: 1,
-						fillOpacity: 0.9
-					}).addTo(map);
-				});
-			}
-		});
+            $.getJSON({
+                url: "/get_route",
+                success: function (result) {
+                    var geojson = {
+                        "type": "LineString",
+                        "coordinates": convertToLonLat(result)
+                    };
+                    L.geoJSON(geojson).addTo(map);
+                    marker.setLatLng(result[0]);
+                    map.setView(result[0], map.getZoom());
+                }
+            });
 
-		(function work() {
-			$.getJSON({
-				url: "/get_position",
-				success: function(result) {
-					if (result[0] != prevLoc[0] || result[1] != prevLoc[1]) {
-						marker.setLatLng(result);
-						map.setView(result, map.getZoom(), { animation: true });
-						prevLoc = result;
-					}
-					setTimeout(work, 5000);
-				}
-			});
-		})();
-	});
-	</script>
-</body>
-</html>
+            $.getJSON({
+                url: "/get_gymcoords",
+                success: function (result) {
+                    $.each(result, function (k, v) {
+                        L.circleMarker([v['lat'], v['lon']], {
+                            radius: 8,
+                            color: "#666",
+                            fillColor: "#ff925b",
+                            weight: 1,
+                            opacity: 1,
+                            fillOpacity: 0.9
+                        }).addTo(map);
+                    });
+                }
+            });
+
+            (function work() {
+                $.getJSON({
+                    url: "/get_position",
+                    success: function (result) {
+                        if (result[0] != prevLoc[0] || result[1] != prevLoc[1]) {
+                            marker.setLatLng(result);
+                            map.setView(result, map.getZoom(), { animation: true });
+                            prevLoc = result;
+                        }
+                        setTimeout(work, 5000);
+                    }
+                });
+            })();
+        });
+    </script>
+{% endblock %}
+
+{% block content %}
+    <h2>MAD Map</h2>
+    <h4><a href="/">Back to Menu</a></h4>
+    <div id="mapouter">
+        <div id="map"></div>
+    </div>
+{% endblock %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -88,7 +88,6 @@
 
 {% block content %}
     <h2>MAD Map</h2>
-    <h4><a href="/">Back to Menu</a></h4>
     <div id="mapouter">
         <div id="map"></div>
     </div>

--- a/templates/match_unknown.html
+++ b/templates/match_unknown.html
@@ -4,44 +4,57 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-    <script>
-        $(document).ready(function () {
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td>" + result[i].name + "</td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='submit_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'dist', title: 'Distance' },
+                { data: 'id', title: 'Match' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [1],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='../" + data + "' width=100>";
                     }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        drawCallback: function () {
-                            $("img.lazy").lazyload();
-                        },
-                        responsive: {{ responsive }},
-                        "order": [[2, "asc"]],
-                        "autoWidth": true
-                    });
+                },
+                {
+                    "targets": [3],
+                    "render": function (data, type, row) {
+                        return "<a href='submit_hash?hash={{ hash }}&id=" + data + "'>Match to this Gym</a>"
+                    }
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[2, "desc"]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+    $(document).ready(function () {
+        $("#navunknown").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Check saved Gyms</h2>
-    <h4><a href="/unknown">Back to unknown Gyms</a></h4>
-    <div id="show-data"></div>
+<h2>Check saved Gyms</h2>
+<h4><a href="/unknown">Back to unknown Gyms</a></h4>
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/match_unknown.html
+++ b/templates/match_unknown.html
@@ -1,66 +1,47 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - match Unknown</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Check saved Gyms</h1></center>
-<center><h4><a href=/unknown>Back to unknown Gyms</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-		  
-		  
-		  $(document).ready(function () {
+    <script>
+        $(document).ready(function () {
 
-		   var displayResources = $('#show-data');
+            var displayResources = $('#show-data');
 
-		   displayResources.text('Loading data ...');
+            displayResources.text('Loading data ...');
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td>" + result[i].name + "</td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='submit_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
+            $.ajax({
+                type: "GET",
+                url: "/near_gym?lat={{ lat }}&lon={{ lon }}",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Distance</th><th>Match</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td>" + result[i].name + "</td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + result[i].dist + "</td><td><a href='submit_hash?hash={{ hash }}&id=" + result[i].id + "'>Match to this Gym</a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-               drawCallback: function(){
-                  $("img.lazy").lazyload();
-               },
-			       responsive: {{ responsive }},
-			   "order": [[ 2, "asc" ]],
-			       "autoWidth": true
-		       } );
-		   }
-		   });
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        drawCallback: function () {
+                            $("img.lazy").lazyload();
+                        },
+                        responsive: {{ responsive }},
+                        "order": [[2, "asc"]],
+                        "autoWidth": true
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Check saved Gyms</h2>
+    <h4><a href="/unknown">Back to unknown Gyms</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -10,42 +10,77 @@
         $(document).ready(function () {
             $("#navraids").addClass("active");
 
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/get_raids",
-                success: function (result) {
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Gympic</th><th>Egg/Mon</th><th>Level</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
-                    for (var i in result) {
-                        if (result[i].type === "egg") {
-                            monegg = "<img class='lazy' data-original='" + result[i].eggPic + "' width=50>"
-                            lvl = 'Egg'
-                            monName = ''
-                        } else {
-                            monegg = "<img class='lazy' data-original='" + result[i].monPic + "' width=100>"
-                            lvl = 'Level: ' + result[i].level
-                            monName = result[i].monname
-                        }
-                        output += "<tr><td>" + result[i].name + "<br><br>Hashvalue: " + result[i].hashvalue + "<br><br>Matchcount: " + result[i].count + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + monName + "<br>" + monegg + "</td><td>" + lvl + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_raid?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Gym</a><br><br><a href='/modify_mon?hash=" + result[i].hashvalue + "&lvl=" + result[i].level + "&gym=" + result[i].id + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Mon</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=raid&redirect=raids'>Delete</a> </td></tr>";
-                    }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");                    
-                    $('table').DataTable({
-                        drawCallback: function () {
-                            $("img.lazy").lazyload();
+            $('#showdata').dataTable({
+                "columns": [
+                    { data: 'name', title: 'Name' },
+                    { data: 'filename', title: 'Hashpic' },
+                    { data: 'gymimage', title: 'Gympic' },
+                    { data: 'type', title: 'Egg/Mon' },
+                    { data: 'level', title: 'Level' },
+                    { data: 'modify', title: 'Last Modify', type: 'date' },
+                    { data: 'creation', title: 'Creation Date', type: 'date' },
+                    { data: '', title: 'Actions' }
+                ],
+                "columnDefs": [
+                    {
+                        targets: [0],
+                        render: function (data, type, row) {
+                            return data + "<br /><br />Hashvalue: " + row.hashvalue + "<br /><br />Matchcount: " + row.count;
                         },
-                        "order": [[{{ sort }}, "desc" ]],
-                        responsive: {{ responsive }},
-                        "autoWidth": true,
-                        columnDefs: [{ targets: [5, 6], type: 'date' }]
-                    });
-                }
+                    },
+                    {
+                        targets: [1, 2],
+                        render: function (data, type, row) {
+                            return "<img class='lazy' data-original='" + data + "' width=100>";
+                        }
+                    },
+                    {
+                        targets: [3],
+                        render: function (data, type, row) {
+                            var monegg = "";
+                            var monName = "";
+                            if (row.type === "egg") {
+                                monegg = "<img class='lazy' data-original='" + row.eggPic + "' width=50>"
+                                monName = ''
+                            } else {
+                                monegg = "<img class='lazy' data-original='" + row.monPic + "' width=100>"
+                                monName = row.monname
+                            }
+
+                            return monName + "<br />" + monegg;
+                        }
+                    },
+                    {
+                        targets: [4],
+                        render: function (data, type, row) {
+                            var lvl = "";
+                            if (row.type === "egg") {
+                                lvl = 'Egg'
+                            } else {
+                                lvl = 'Level: ' + row.level
+                            }
+
+                            return lvl;
+                        }
+                    },
+                    {
+                        targets: [7],
+                        render: function (data, type, row) {
+                            var modifyRaid = "<a href='/modify_raid?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Gym</a>";
+                            var modifyMon = "<a href='/modify_mon?hash=" + row.hashvalue + "&lvl=" + row.level + "&gym=" + row.id + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Mon</a>";
+                            var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=raid&redirect=raids'>Delete</a>";
+
+                            return modifyRaid + "<br /><br/>" + modifyMon + "<br /><br />" + deleteHash;
+                        }
+                    }
+                ],
+                "drawCallback": function () {
+                    $("img.lazy").lazyload();
+                },
+                "order": [[{{ sort }}, "desc" ]],
+                "responsive": {{ responsive }},
+                "autoWidth": true,
+                "ajax": "/get_raids"
             });
         });
     </script>
@@ -53,7 +88,6 @@
 
 {% block content %}
     <h2>Check saved Raids</h2>
-    <h4><a href="/">Back to Menu</a></h4>
     <div id="show-data"></div>
 {% endblock %}
 

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -22,20 +22,20 @@
             ],
             "columnDefs": [
                 {
-                    targets: [0],
-                    render: function (data, type, row) {
+                    "targets": [0],
+                    "render": function (data, type, row) {
                         return data + "<br />Hashvalue: " + row.hashvalue + "<br />Matchcount: " + row.count;
                     },
                 },
                 {
-                    targets: [1, 2],
-                    render: function (data, type, row) {
+                    "targets": [1, 2],
+                    "render": function (data, type, row) {
                         return "<img class='lazy' data-original='" + data + "' width=100>";
                     }
                 },
                 {
-                    targets: [3],
-                    render: function (data, type, row) {
+                    "targets": [3],
+                    "render": function (data, type, row) {
                         var monegg = "";
                         var monName = "";
                         if (row.type === "egg") {
@@ -50,8 +50,8 @@
                     }
                 },
                 {
-                    targets: [4],
-                    render: function (data, type, row) {
+                    "targets": [4],
+                    "render": function (data, type, row) {
                         var lvl = "";
                         if (row.type === "egg") {
                             lvl = 'Egg'
@@ -63,8 +63,8 @@
                     }
                 },
                 {
-                    targets: [7],
-                    render: function (data, type, row) {
+                    "targets": [7],
+                    "render": function (data, type, row) {
                         var modifyRaid = "<a href='/modify_raid?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Gym</a>";
                         var modifyMon = "<a href='/modify_mon?hash=" + row.hashvalue + "&lvl=" + row.level + "&gym=" + row.id + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Mon</a>";
                         var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=raid&redirect=raids'>Delete</a>";

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -97,6 +97,10 @@
 {% endblock %}
 
 {% block content %}
+{% if title %}
+<h2>{{ title }}</h2>
+{% else %}
 <h2>Check saved Raids</h2>
+{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -1,82 +1,60 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - show Gym Matching</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Check saved Raids</h1>
-<h4><a href=/>Back to Menu</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
+    <script>
+        $(document).ready(function () {
+            $("#navraids").addClass("active");
 
+            var displayResources = $('#show-data');
 
-		  $(document).ready(function () {
+            displayResources.text('Loading data ...');
 
-		   var displayResources = $('#show-data');
+            $.ajax({
+                type: "GET",
+                url: "/get_raids",
+                success: function (result) {
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Name</th><th>Hashpic</th><th>Gympic</th><th>Egg/Mon</th><th>Level</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
+                    for (var i in result) {
+                        if (result[i].type === "egg") {
+                            monegg = "<img class='lazy' data-original='" + result[i].eggPic + "' width=50>"
+                            lvl = 'Egg'
+                            monName = ''
+                        } else {
+                            monegg = "<img class='lazy' data-original='" + result[i].monPic + "' width=100>"
+                            lvl = 'Level: ' + result[i].level
+                            monName = result[i].monname
+                        }
+                        output += "<tr><td>" + result[i].name + "<br><br>Hashvalue: " + result[i].hashvalue + "<br><br>Matchcount: " + result[i].count + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + monName + "<br>" + monegg + "</td><td>" + lvl + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_raid?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Gym</a><br><br><a href='/modify_mon?hash=" + result[i].hashvalue + "&lvl=" + result[i].level + "&gym=" + result[i].id + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Mon</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=raid&redirect=raids'>Delete</a> </td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   displayResources.text('Loading data ...');
+                    displayResources.html(output);
+                    $("table").addClass("table");                    
+                    $('table').DataTable({
+                        drawCallback: function () {
+                            $("img.lazy").lazyload();
+                        },
+                        "order": [[{{ sort }}, "desc" ]],
+                        responsive: {{ responsive }},
+                        "autoWidth": true,
+                        columnDefs: [{ targets: [5, 6], type: 'date' }]
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/get_raids",
-		   success: function(result)
-		   {
-		   console.log(result);
-		   var output="<table><thead><tr><th>Name</th><th>Hashpic</th><th>Gympic</th><th>Egg/Mon</th><th>Level</th><th>Last Modify</th><th>Creation Date</th><th>Actions</th></thead><tbody>";
-		   for (var i in result)
-		   {
-			   if (result[i].type === "egg") {
-			   	monegg = "<img class='lazy' data-original='" + result[i].eggPic + "' width=50>"
-				lvl = 'Egg'
-				monName = ''
-			   } else {
-			   	monegg = "<img class='lazy' data-original='" + result[i].monPic + "' width=100>"
-				lvl = 'Level: ' + result[i].level
-				monName = result[i].monname
-			   }
-		   output+="<tr><td>" + result[i].name + "<br><br>Hashvalue: " + result[i].hashvalue + "<br><br>Matchcount: " + result[i].count + "</td><td><img class='lazy' data-original='" + result[i].filename + "' width=100></td><td><img class='lazy' data-original='" + result[i].gymimage + "' width=100></td><td>" + monName + "<br>" + monegg + "</td><td>" + lvl + "</td><td>" + result[i].modify + "</td><td>" + result[i].creation + "</td><td><a href='/modify_raid?hash=" + result[i].hashvalue + "&lat=" + result[i].lat +"&lon=" + result[i].lon + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Gym</a><br><br><a href='/modify_mon?hash=" + result[i].hashvalue + "&lvl=" + result[i].level +"&gym=" + result[i].id + "&mon=" + result[i].mon + "&lvl=" + result[i].level + "'>Change Mon</a><br><br><a href='/delete_hash?hash=" + result[i].hashvalue + "&type=raid&redirect=raids'>Delete</a> </td></tr>";
-		   }
-		   output+="</tbody></table>";
-
-		   displayResources.html(output);
-		   $("table").addClass("table");
+{% block content %}
+    <h2>Check saved Raids</h2>
+    <h4><a href="/">Back to Menu</a></h4>
+    <div id="show-data"></div>
+{% endblock %}
 
 
-		   $('table').DataTable( {
-                   drawCallback: function(){
-                       $("img.lazy").lazyload();
-                   },
-		           "order": [[ {{ sort }}, "desc" ]],
-			       responsive: {{ responsive }},
-			       "autoWidth": true,
-			       columnDefs: [{ targets: [5, 6], type: 'date'}]
-
-		       } );
-
-
-		   }
-		   });
-
-		  });
-		  </script>
-
-</body>
-</html>

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -25,7 +25,7 @@
                     {
                         targets: [0],
                         render: function (data, type, row) {
-                            return data + "<br /><br />Hashvalue: " + row.hashvalue + "<br /><br />Matchcount: " + row.count;
+                            return data + "<br />Hashvalue: " + row.hashvalue + "<br />Matchcount: " + row.count;
                         },
                     },
                     {
@@ -70,7 +70,7 @@
                             var modifyMon = "<a href='/modify_mon?hash=" + row.hashvalue + "&lvl=" + row.level + "&gym=" + row.id + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Mon</a>";
                             var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=raid&redirect=raids'>Delete</a>";
 
-                            return modifyRaid + "<br /><br/>" + modifyMon + "<br /><br />" + deleteHash;
+                            return modifyRaid + "<br />" + modifyMon + "<br />" + deleteHash;
                         }
                     }
                 ],

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -4,91 +4,99 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-    <script>
-        $(document).ready(function () {
-            $("#navraids").addClass("active");
-
-            $('#show-data').dataTable({
-                "columns": [
-                    { data: 'name', title: 'Name' },
-                    { data: 'filename', title: 'Hashpic' },
-                    { data: 'gymimage', title: 'Gympic' },
-                    { data: 'type', title: 'Egg/Mon' },
-                    { data: 'level', title: 'Level' },
-                    { data: 'modify', title: 'Last Modify', type: 'date' },
-                    { data: 'creation', title: 'Creation Date', type: 'date' },
-                    { data: '', title: 'Actions' }
-                ],
-                "columnDefs": [
-                    {
-                        targets: [0],
-                        render: function (data, type, row) {
-                            return data + "<br />Hashvalue: " + row.hashvalue + "<br />Matchcount: " + row.count;
-                        },
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'name', title: 'Name' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'gymimage', title: 'Gympic' },
+                { data: 'type', title: 'Egg/Mon' },
+                { data: 'level', title: 'Level' },
+                { data: 'modify', title: 'Last Modify', type: 'date' },
+                { data: 'creation', title: 'Creation Date', type: 'date' },
+                { data: '', title: 'Actions' }
+            ],
+            "columnDefs": [
+                {
+                    targets: [0],
+                    render: function (data, type, row) {
+                        return data + "<br />Hashvalue: " + row.hashvalue + "<br />Matchcount: " + row.count;
                     },
-                    {
-                        targets: [1, 2],
-                        render: function (data, type, row) {
-                            return "<img class='lazy' data-original='" + data + "' width=100>";
-                        }
-                    },
-                    {
-                        targets: [3],
-                        render: function (data, type, row) {
-                            var monegg = "";
-                            var monName = "";
-                            if (row.type === "egg") {
-                                monegg = "<img class='lazy' data-original='" + row.eggPic + "' width=50>"
-                                monName = ''
-                            } else {
-                                monegg = "<img class='lazy' data-original='" + row.monPic + "' width=100>"
-                                monName = row.monname
-                            }
-
-                            return monName + "<br />" + monegg;
-                        }
-                    },
-                    {
-                        targets: [4],
-                        render: function (data, type, row) {
-                            var lvl = "";
-                            if (row.type === "egg") {
-                                lvl = 'Egg'
-                            } else {
-                                lvl = 'Level: ' + row.level
-                            }
-
-                            return lvl;
-                        }
-                    },
-                    {
-                        targets: [7],
-                        render: function (data, type, row) {
-                            var modifyRaid = "<a href='/modify_raid?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Gym</a>";
-                            var modifyMon = "<a href='/modify_mon?hash=" + row.hashvalue + "&lvl=" + row.level + "&gym=" + row.id + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Mon</a>";
-                            var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=raid&redirect=raids'>Delete</a>";
-
-                            return modifyRaid + "<br />" + modifyMon + "<br />" + deleteHash;
-                        }
-                    }
-                ],
-                "drawCallback": function () {
-                    $("img.lazy").lazyload();
                 },
-                "order": [[{{ sort }}, "desc" ]],
-                "responsive": {{ responsive }},
-                "autoWidth": true,
-                "ajax": "/get_raids"
-            });
+                {
+                    targets: [1, 2],
+                    render: function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
+                    }
+                },
+                {
+                    targets: [3],
+                    render: function (data, type, row) {
+                        var monegg = "";
+                        var monName = "";
+                        if (row.type === "egg") {
+                            monegg = "<img class='lazy' data-original='" + row.eggPic + "' width=50>"
+                            monName = ''
+                        } else {
+                            monegg = "<img class='lazy' data-original='" + row.monPic + "' width=100>"
+                            monName = row.monname
+                        }
+
+                        return monName + "<br />" + monegg;
+                    }
+                },
+                {
+                    targets: [4],
+                    render: function (data, type, row) {
+                        var lvl = "";
+                        if (row.type === "egg") {
+                            lvl = 'Egg'
+                        } else {
+                            lvl = 'Level: ' + row.level
+                        }
+
+                        return lvl;
+                    }
+                },
+                {
+                    targets: [7],
+                    render: function (data, type, row) {
+                        var modifyRaid = "<a href='/modify_raid?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Gym</a>";
+                        var modifyMon = "<a href='/modify_mon?hash=" + row.hashvalue + "&lvl=" + row.level + "&gym=" + row.id + "&mon=" + row.mon + "&lvl=" + row.level + "'>Change Mon</a>";
+                        var deleteHash = "<a href='/delete_hash?hash=" + row.hashvalue + "&type=raid&redirect=raids'>Delete</a>";
+
+                        return modifyRaid + "<br />" + modifyMon + "<br />" + deleteHash;
+                    }
+                }
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[{{ sort }}, "desc" ]],
+            "responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+    $(document).ready(function () {
+        $("#navraids").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/get_raids",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Check saved Raids</h2>
-    <table id="show-data" class="table"></table>
+<h2>Check saved Raids</h2>
+<table id="show-data" class="table"></table>
 {% endblock %}
-
-

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -10,7 +10,7 @@
         $(document).ready(function () {
             $("#navraids").addClass("active");
 
-            $('#showdata').dataTable({
+            $('#show-data').dataTable({
                 "columns": [
                     { data: 'name', title: 'Name' },
                     { data: 'filename', title: 'Hashpic' },
@@ -88,7 +88,7 @@
 
 {% block content %}
     <h2>Check saved Raids</h2>
-    <div id="show-data"></div>
+    <table id="show-data" class="table"></table>
 {% endblock %}
 
 

--- a/templates/raids.html
+++ b/templates/raids.html
@@ -97,10 +97,6 @@
 {% endblock %}
 
 {% block content %}
-{% if title %}
-<h2>{{ title }}</h2>
-{% else %}
 <h2>Check saved Raids</h2>
-{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -17,7 +17,7 @@
             ],
             "columnDefs": [
                 {
-                    "targets": [0, 1],
+                    "targets": [0],
                     "render": function (data, type, row) {
                         return "<img class='lazy' data-original='" + data + "' width=100>";
                     }

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -1,76 +1,58 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - show success Screens</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Show Screens</h1>
-<h4><a href=/>Back to Menu</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-		  
-		  
-		  $(document).ready(function () {
+    <script>
+        $(document).ready(function () {
+            $("#navscreens").addClass("active");
 
-		   var displayResources = $('#show-data');
+            var displayResources = $('#show-data');
 
-		   displayResources.text('Loading data ...');
+            displayResources.text('Loading data ...');
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/get_screens",
-		   success: function(result)
-		   {
-            result.sort(function (a, b) {
-                    if (a.creation > b.creation) {
-                        return -1;
-                       }
-                   if (a.creation < b.creation) {
-                         return 1;
-                     }
-                   return 0;
+            $.ajax({
+                type: "GET",
+                url: "/get_screens",
+                success: function (result) {
+                    result.sort(function (a, b) {
+                        if (a.creation > b.creation) {
+                            return -1;
+                        }
+                        if (a.creation < b.creation) {
+                            return 1;
+                        }
+                        return 0;
+                    });
+                    console.log(result);
+                    var output = "<table><thead><tr><th>Image</th><th>Filename</th><th>Creation Date</th></thead><tbody>";
+                    for (var i in result) {
+                        output += "<tr><td><img class='lazy' data-original='" + result[i].filename + "' width=400></td><td>" + result[i].filename + "</td><td>" + result[i].creation + "</td></tr>";
+                    }
+                    output += "</tbody></table>";
+
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        drawCallback: function () {
+                            $("img.lazy").lazyload();
+                        },
+                        "order": [[2, "desc"]],
+                        responsive: {{ responsive }},
+                        "autoWidth": true,
+                        columnDefs: [{ targets: [2], type: 'date' }]
+                    });
+                }
             });
-		   console.log(result);
-		   var output="<table><thead><tr><th>Image</th><th>Filename</th><th>Creation Date</th></thead><tbody>";
-		   for (var i in result)
-		   {
-		   output+="<tr><td><img class='lazy' data-original='" + result[i].filename + "' width=400></td><td>" + result[i].filename + "</td><td>" + result[i].creation + "</td></tr>";
-		   }
-		   output+="</tbody></table>";
+        });
+    </script>
+{% endblock %}
 
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-                   drawCallback: function(){
-                     $("img.lazy").lazyload();
-                   },
-		           "order": [[ 2, "desc" ]],
-			       responsive: {{ responsive }},
-			       "autoWidth": true,
-			       columnDefs: [{ targets: [2], type: 'date'}]
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-</body>
-</html>
+{% block content %}
+    <h2>Show Screens</h2>
+    <h4><a href="/">Back to Menu</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -53,6 +53,5 @@
 
 {% block content %}
     <h2>Show Screens</h2>
-    <h4><a href="/">Back to Menu</a></h4>
     <div id="show-data"></div>
 {% endblock %}

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -35,10 +35,6 @@
     $(document).ready(function () {
         $("#navscreens").addClass("active");
 
-        var displayResources = $('#show-data');
-
-        displayResources.text('Loading data ...');
-
         $.ajax({
             type: "GET",
             url: "/get_screens",
@@ -51,6 +47,10 @@
 {% endblock %}
 
 {% block content %}
+{% if title %}
+<h2>{{ title }}</h2>
+{% else %}
 <h2>Show Screens</h2>
-<div id="show-data"></div>
+{% endif %}
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -26,8 +26,8 @@
             "drawCallback": function () {
                 $("img.lazy").lazyload();
             },
-            //"order": [[2, "desc"]],
-            //"responsive": {{ responsive }},
+            "order": [[2, "desc"]],
+            "responsive": {{ responsive }},
             "autoWidth": true
         });
     }
@@ -47,10 +47,6 @@
 {% endblock %}
 
 {% block content %}
-{% if title %}
-<h2>{{ title }}</h2>
-{% else %}
 <h2>Show Screens</h2>
-{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/screens.html
+++ b/templates/screens.html
@@ -4,54 +4,53 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-    <script>
-        $(document).ready(function () {
-            $("#navscreens").addClass("active");
-
-            var displayResources = $('#show-data');
-
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/get_screens",
-                success: function (result) {
-                    result.sort(function (a, b) {
-                        if (a.creation > b.creation) {
-                            return -1;
-                        }
-                        if (a.creation < b.creation) {
-                            return 1;
-                        }
-                        return 0;
-                    });
-                    console.log(result);
-                    var output = "<table><thead><tr><th>Image</th><th>Filename</th><th>Creation Date</th></thead><tbody>";
-                    for (var i in result) {
-                        output += "<tr><td><img class='lazy' data-original='" + result[i].filename + "' width=400></td><td>" + result[i].filename + "</td><td>" + result[i].creation + "</td></tr>";
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'filename', title: 'Image' },
+                { data: 'filename', title: 'Filename' },
+                { data: 'creation', title: 'Creation Date', type: 'date' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [0, 1],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='" + data + "' width=100>";
                     }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        drawCallback: function () {
-                            $("img.lazy").lazyload();
-                        },
-                        "order": [[2, "desc"]],
-                        responsive: {{ responsive }},
-                        "autoWidth": true,
-                        columnDefs: [{ targets: [2], type: 'date' }]
-                    });
                 }
-            });
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            //"order": [[2, "desc"]],
+            //"responsive": {{ responsive }},
+            "autoWidth": true
         });
-    </script>
+    }
+
+    $(document).ready(function () {
+        $("#navscreens").addClass("active");
+
+        var displayResources = $('#show-data');
+
+        displayResources.text('Loading data ...');
+
+        $.ajax({
+            type: "GET",
+            url: "/get_screens",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
+        });
+    });
+</script>
 {% endblock %}
 
 {% block content %}
-    <h2>Show Screens</h2>
-    <div id="show-data"></div>
+<h2>Show Screens</h2>
+<div id="show-data"></div>
 {% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -70,7 +70,7 @@
                 $("img.lazy").lazyload();
             },
             "order": [[4, "desc"]],
-            //"responsive": {{ responsive }},
+            "responsive": {{ responsive }},
             "autoWidth": true
         });
     }

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -11,7 +11,7 @@
             $("#navunknown").addClass("active");
 
             $('#show-data').dataTable({
-                "column": [
+                "columns": [
                     { data: 'hashvalue', title: 'Hash' },
                     { data: 'filename', title: 'Hashpic' },
                     { data: 'lat', title: 'Lat' },

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -73,7 +73,9 @@
                     "type": "GET",
                     "url":"get_unknows",
                     "dataSrc": function (json) {
-                        return $.parseJSON(json.d);
+                        console.log(json);
+                        console.log(JSON.stringify(json));
+                        return $.parseJSON(json);
                     }
                 },
             });

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -1,75 +1,54 @@
-<html
-<head>
- <meta charset="utf-8">
- <title>MADMIN - show unknown Gym</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.bootstrap.min.css">
-  <link rel="stylesheet" href=" https://cdn.datatables.net/responsive/2.2.3/css/responsive.bootstrap.min.css">
-  <link rel="shortcut icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
-  <link rel="icon" href={{ url_for('static', filename='favicon.ico') }} type="image/x-icon">
- </head>
-<body>
-<center><h1>Check unknown Gyms</h1>
-<h4><a href=/>Back to Menu</a></h4></center>
-<div id="show-data"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap.min.js"></script>
-<script src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.2.3/js/responsive.bootstrap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+﻿{% extends "base.html" %}
 
-<script>
+{% block header %}
+{% endblock %}
 
+{% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
+    <script>
+        $(document).ready(function () {
+            $("#navunkown").addClass("active");
 
+            var displayResources = $('#show-data');
 
-		  $(document).ready(function () {
+            displayResources.text('Loading data ...');
 
-		   var displayResources = $('#show-data');
+            $.ajax({
+                type: "GET",
+                url: "/get_unknows",
+                success: function (result) {
+                    var output = "<table><thead><tr><th>Hash</th><th>Hashpic</th><th>Lat</th><th>Lon</th><th>Creation Date</th></thead><tbody>";
+                    for (var i in result) {
+                        if (result[i].lat === "9999") {
+                            vlat = 'MADBot'
+                            vlon = 'MADBot'
+                        } else {
+                            vlat = result[i].lat
+                            vlon = result[i].lon
+                        }
+                        output += "<tr><td>" + result[i].hashvalue + "<br><br><a href='/match_unknows?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Match Gym</a><br><a href='/delete_file?hash=" + result[i].hashvalue + "&type=gym&redirect=unknown'>Delete</a></td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + vlat + "</td><td>" + vlon + "</td><td>" + result[i].creation + "</td></tr>";
+                    }
+                    output += "</tbody></table>";
 
-		   displayResources.text('Loading data ...');
+                    displayResources.html(output);
+                    $("table").addClass("table");
+                    $('table').DataTable({
+                        drawCallback: function () {
+                            $("img.lazy").lazyload();
+                        },
+                        "order": [[4, "desc"]],
+                        responsive: {{ responsive }},
+                        columnDefs: [{ targets: [4], type: 'date' }]
+                    });
+                }
+            });
+        });
+    </script>
+{% endblock %}
 
-		   $.ajax({
-		   type: "GET",
-		   url: "/get_unknows",
-		   success: function(result)
-		   {
-
-		   var output="<table><thead><tr><th>Hash</th><th>Hashpic</th><th>Lat</th><th>Lon</th><th>Creation Date</th></thead><tbody>";
-		   for (var i in result)
-		   {
-			   if (result[i].lat === "9999") {
-				   vlat = 'MADBot'
-				   vlon = 'MADBot'
-			   } else {
-			   	   vlat = result[i].lat
-				   vlon = result[i].lon
-			   }
-		   output+="<tr><td>" + result[i].hashvalue + "<br><br><a href='/match_unknows?hash=" + result[i].hashvalue + "&lat=" + result[i].lat+"&lon=" + result[i].lon + "'>Match Gym</a><br><a href='/delete_file?hash=" + result[i].hashvalue + "&type=gym&redirect=unknown'>Delete</a></td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + vlat  + "</td><td>" + vlon + "</td><td>" + result[i].creation + "</td></tr>";
-		   }
-		   output+="</tbody></table>";
-
-		   displayResources.html(output);
-		   $("table").addClass("table");
-		   $('table').DataTable( {
-                   drawCallback: function(){
-                      $("img.lazy").lazyload();
-                   },
-		           "order": [[ 4, "desc" ]],
-			       responsive: {{ responsive }},
-			       columnDefs: [{ targets: [4], type: 'date'}]
-		       } );
-		   }
-		   });
-
-		  });
-</script>
-
-
-</body>
-</html>
+{% block content %}
+    <h2>Check unknown Gyms</h2>
+    <h4><a href="/">Back to Menu</a></h4>
+    <div id="show-data"></div>
+{% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -74,7 +74,7 @@
                     $("img.lazy").lazyload();
                 },
                 "order": [[4, "desc"]],
-                "responsive": {{ responsive }},
+                //"responsive": {{ responsive }},
                 "autoWidth": true
             });
         }
@@ -90,6 +90,7 @@
                 setGrid('#show-data', result);
             }
         });
+    }
 </script>
 {% endblock %}
 

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -75,5 +75,5 @@
 
 {% block content %}
     <h2>Check unknown Gyms</h2>
-    <div id="show-data"></div>
+    <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -11,22 +11,22 @@
             $("#navunknown").addClass("active");
 
             $('#show-data').dataTable({
-                column: [
-                    { data: 'hashvalue', title: 'Hash'},
-                    { data: 'filename', title: 'Hashpic'},
-                    { data: 'lat', title: 'Lat'},
-                    { data: 'lon', title: 'Lon'},
-                    { data: 'creation', title: 'Creation Date', type: 'date'},
+                "column": [
+                    { data: 'hashvalue', title: 'Hash' },
+                    { data: 'filename', title: 'Hashpic' },
+                    { data: 'lat', title: 'Lat' },
+                    { data: 'lon', title: 'Lon' },
+                    { data: 'creation', title: 'Creation Date', type: 'date' }
                 ],
-                columnDefs: [
+                "columnDefs": [
                     {
                         targets: [0],
                         render: function (data, type, row) {
-                            var matchunknowns = "<a href='/match_unknows?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Match Gym</a>";
-                            var deletefile = "<a href='/delete_file?hash=" + result[i].hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
+                            var matchunknowns = "<a href='/match_unknows?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Match Gym</a>";
+                            var deletefile = "<a href='/delete_file?hash=" + row.hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
 
                             return data + "<br /><br />" + matchunknowns + "<br />" + deletefile;
-                        },
+                        }
                     },
                     {
                         targets: [1],
@@ -54,7 +54,7 @@
                             if (row.lat === "9999") {
                                 vlon = 'MADBot'
                             } else {
-                                vlon = result[i].lon
+                                vlon = row.lon
                             }
 
                             return vlon;
@@ -64,7 +64,7 @@
                 "drawCallback": function () {
                     $("img.lazy").lazyload();
                 },
-                "order": [[4, "desc"]],
+                "order": [[4, "desc" ]],
                 "responsive": {{ responsive }},
                 "autoWidth": true,
                 "ajax": "/get_unknows"

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -8,76 +8,71 @@
 
 <script>
     function setGrid(tableGridHtmlId, gridData) {
-        var grid;
+        $(tableGridHtmlId).DataTable({
+            "data": gridData,
+            "columns": [
+                { data: 'hashvalue', title: 'Hash' },
+                { data: 'filename', title: 'Hashpic' },
+                { data: 'lat', title: 'Lat' },
+                { data: 'lon', title: 'Lon' },
+                { data: 'creation', title: 'Creation Date', type: 'date' }
+            ],
+            "columnDefs": [
+                {
+                    "targets": [0],
+                    "render": function (data, type, row) {
+                        var matchunknowns = "<a href='/match_unknows?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Match Gym</a>";
+                        var deletefile = "<a href='/delete_file?hash=" + row.hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
 
-        if ($.fn.dataTable.isDataTable(tableGridHtmlId)) {
-            grid = $(tableGridHtmlId).DataTable();
-        } else {
-            grid = $(tableGridHtmlId).DataTable({
-                "columns": [
-                    { data: 'hashvalue', title: 'Hash' },
-                    { data: 'filename', title: 'Hashpic' },
-                    { data: 'lat', title: 'Lat' },
-                    { data: 'lon', title: 'Lon' },
-                    { data: 'creation', title: 'Creation Date', type: 'date' }
-                ],
-                "columnDefs": [
-                    {
-                        "targets": [0],
-                        "render": function (data, type, row) {
-                            var matchunknowns = "<a href='/match_unknows?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Match Gym</a>";
-                            var deletefile = "<a href='/delete_file?hash=" + row.hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
-
-                            return data + "<br /><br />" + matchunknowns + "<br />" + deletefile;
-                        }
-                    },
-                    {
-                        "targets": [1],
-                        "render": function (data, type, row) {
-                            return "<img class='lazy' data-original='../" + data + "' width=100>";
-                        }
-                    },
-                    {
-                        "targets": [2],
-                        "render": function (data, type, row) {
-                            var vlat = "";
-                            if (row.lat === "9999") {
-                                vlat = 'MADBot'
-                            } else {
-                                vlat = row.lat
-                            }
-
-                            return "" + vlat;
-                        }
-                    },
-                    {
-                        "targets": [3],
-                        "render": function (data, type, row) {
-                            var vlon = "";
-                            if (row.lat === "9999") {
-                                vlon = 'MADBot'
-                            } else {
-                                vlon = row.lon
-                            }
-
-                            return "" + vlon;
-                        }
-                    },
-                    {
-                        "targets": [4],
-                        "render": function (data, trype, row) {
-                            return "" + data;
-                        }
+                        return data + "<br /><br />" + matchunknowns + "<br />" + deletefile;
                     }
-                ],
-                "drawCallback": function () {
-                    $("img.lazy").lazyload();
                 },
-                "order": [[4, "desc"]],
-                //"responsive": {{ responsive }},
-                "autoWidth": true
-            });
-        }
+                {
+                    "targets": [1],
+                    "render": function (data, type, row) {
+                        return "<img class='lazy' data-original='../" + data + "' width=100>";
+                    }
+                },
+                {
+                    "targets": [2],
+                    "render": function (data, type, row) {
+                        var vlat = "";
+                        if (row.lat === "9999") {
+                            vlat = 'MADBot'
+                        } else {
+                            vlat = row.lat
+                        }
+
+                        return "" + vlat;
+                    }
+                },
+                {
+                    "targets": [3],
+                    "render": function (data, type, row) {
+                        var vlon = "";
+                        if (row.lat === "9999") {
+                            vlon = 'MADBot'
+                        } else {
+                            vlon = row.lon
+                        }
+
+                        return "" + vlon;
+                    }
+                },
+                {
+                    "targets": [4],
+                    "render": function (data, trype, row) {
+                        return "" + data;
+                    }
+                }
+            ],
+            "drawCallback": function () {
+                $("img.lazy").lazyload();
+            },
+            "order": [[4, "desc"]],
+            //"responsive": {{ responsive }},
+            "autoWidth": true
+        });
     }
 
     $(document).ready(function () {
@@ -95,6 +90,6 @@
 {% endblock %}
 
 {% block content %}
-    <h2>Check unknown Gyms</h2>
-    <table id="show-data" class="table"></table>
+<h2>Check unknown Gyms</h2>
+<table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -4,13 +4,16 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.js"></script>
 
-    <script>
-        $(document).ready(function () {
-            $("#navunknown").addClass("active");
+<script>
+    function setGrid(tableGridHtmlId, gridData) {
+        var grid;
 
-            $('#show-data').dataTable({
+        if ($.fn.dataTable.isDataTable(tableGridHtmlId)) {
+            grid = $(tableGridHtmlId).DataTable();
+        } else {
+            grid = $(tableGridHtmlId).DataTable({
                 "columns": [
                     { data: 'hashvalue', title: 'Hash' },
                     { data: 'filename', title: 'Hashpic' },
@@ -20,8 +23,8 @@
                 ],
                 "columnDefs": [
                     {
-                        targets: [0],
-                        render: function (data, type, row) {
+                        "targets": [0],
+                        "render": function (data, type, row) {
                             var matchunknowns = "<a href='/match_unknows?hash=" + row.hashvalue + "&lat=" + row.lat + "&lon=" + row.lon + "'>Match Gym</a>";
                             var deletefile = "<a href='/delete_file?hash=" + row.hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
 
@@ -29,14 +32,14 @@
                         }
                     },
                     {
-                        targets: [1],
-                        render: function (data, type, row) {
+                        "targets": [1],
+                        "render": function (data, type, row) {
                             return "<img class='lazy' data-original='../" + data + "' width=100>";
                         }
                     },
                     {
-                        targets: [2],
-                        render: function (data, type, row) {
+                        "targets": [2],
+                        "render": function (data, type, row) {
                             var vlat = "";
                             if (row.lat === "9999") {
                                 vlat = 'MADBot'
@@ -44,12 +47,12 @@
                                 vlat = row.lat
                             }
 
-                            return vlat;
+                            return "" + vlat;
                         }
                     },
                     {
-                        targets: [3],
-                        render: function (data, type, row) {
+                        "targets": [3],
+                        "render": function (data, type, row) {
                             var vlon = "";
                             if (row.lat === "9999") {
                                 vlon = 'MADBot'
@@ -57,30 +60,37 @@
                                 vlon = row.lon
                             }
 
-                            return vlon;
+                            return "" + vlon;
+                        }
+                    },
+                    {
+                        "targets": [4],
+                        "render": function (data, trype, row) {
+                            return "" + data;
                         }
                     }
                 ],
                 "drawCallback": function () {
                     $("img.lazy").lazyload();
                 },
-                "order": [[4, "desc" ]],
+                "order": [[4, "desc"]],
                 "responsive": {{ responsive }},
-                "autoWidth": true,
-                "ajax": {
-                    "dataType": 'json',
-                    "contentType": "application/json; charset=utf-8",
-                    "type": "GET",
-                    "url":"get_unknows",
-                    "dataSrc": function (json) {
-                        console.log(json);
-                        console.log(JSON.stringify(json));
-                        return $.parseJSON(json);
-                    }
-                },
+                "autoWidth": true
             });
+        }
+    }
+
+    $(document).ready(function () {
+        $("#navunknown").addClass("active");
+
+        $.ajax({
+            type: "GET",
+            url: "/get_unknows",
+            success: function (result) {
+                setGrid('#show-data', result);
+            }
         });
-    </script>
+</script>
 {% endblock %}
 
 {% block content %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -67,7 +67,15 @@
                 "order": [[4, "desc" ]],
                 "responsive": {{ responsive }},
                 "autoWidth": true,
-                "ajax": "/get_unknows"
+                "ajax": {
+                    "dataType": 'json',
+                    "contentType": "application/json; charset=utf-8",
+                    "type": "GET",
+                    "url":"get_unknows",
+                    "dataSrc": function (json) {
+                        return $.parseJSON(json.d);
+                    }
+                },
             });
         });
     </script>

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -90,7 +90,7 @@
                 setGrid('#show-data', result);
             }
         });
-    }
+    });
 </script>
 {% endblock %}
 

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -10,38 +10,64 @@
         $(document).ready(function () {
             $("#navunknown").addClass("active");
 
-            var displayResources = $('#show-data');
+            $('#show-data').dataTable({
+                column: [
+                    { data: 'hashvalue', title: 'Hash'},
+                    { data: 'filename', title: 'Hashpic'},
+                    { data: 'lat', title: 'Lat'},
+                    { data: 'lon', title: 'Lon'},
+                    { data: 'creation', title: 'Creation Date', type: 'date'},
+                ],
+                columnDefs: [
+                    {
+                        targets: [0],
+                        render: function (data, type, row) {
+                            var matchunknowns = "<a href='/match_unknows?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Match Gym</a>";
+                            var deletefile = "<a href='/delete_file?hash=" + result[i].hashvalue + "&type=gym&redirect=unknown'>Delete</a>";
 
-            displayResources.text('Loading data ...');
-
-            $.ajax({
-                type: "GET",
-                url: "/get_unknows",
-                success: function (result) {
-                    var output = "<table><thead><tr><th>Hash</th><th>Hashpic</th><th>Lat</th><th>Lon</th><th>Creation Date</th></thead><tbody>";
-                    for (var i in result) {
-                        if (result[i].lat === "9999") {
-                            vlat = 'MADBot'
-                            vlon = 'MADBot'
-                        } else {
-                            vlat = result[i].lat
-                            vlon = result[i].lon
-                        }
-                        output += "<tr><td>" + result[i].hashvalue + "<br><br><a href='/match_unknows?hash=" + result[i].hashvalue + "&lat=" + result[i].lat + "&lon=" + result[i].lon + "'>Match Gym</a><br><a href='/delete_file?hash=" + result[i].hashvalue + "&type=gym&redirect=unknown'>Delete</a></td><td><img class='lazy' data-original='../" + result[i].filename + "' width=100></td><td>" + vlat + "</td><td>" + vlon + "</td><td>" + result[i].creation + "</td></tr>";
-                    }
-                    output += "</tbody></table>";
-
-                    displayResources.html(output);
-                    $("table").addClass("table");
-                    $('table').DataTable({
-                        drawCallback: function () {
-                            $("img.lazy").lazyload();
+                            return data + "<br /><br />" + matchunknowns + "<br />" + deletefile;
                         },
-                        "order": [[4, "desc"]],
-                        responsive: {{ responsive }},
-                        columnDefs: [{ targets: [4], type: 'date' }]
-                    });
-                }
+                    },
+                    {
+                        targets: [1],
+                        render: function (data, type, row) {
+                            return "<img class='lazy' data-original='../" + data + "' width=100>";
+                        }
+                    },
+                    {
+                        targets: [2],
+                        render: function (data, type, row) {
+                            var vlat = "";
+                            if (row.lat === "9999") {
+                                vlat = 'MADBot'
+                            } else {
+                                vlat = row.lat
+                            }
+
+                            return vlat;
+                        }
+                    },
+                    {
+                        targets: [3],
+                        render: function (data, type, row) {
+                            var vlon = "";
+                            if (row.lat === "9999") {
+                                vlon = 'MADBot'
+                            } else {
+                                vlon = result[i].lon
+                            }
+
+                            return vlon;
+                        }
+                    }
+                ],
+                "drawCallback": function () {
+                    $("img.lazy").lazyload();
+                },
+                "order": [[4, "desc"]],
+                "responsive": {{ responsive }},
+                "autoWidth": true,
+                "ajax": "/get_unknows"
             });
         });
     </script>

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -90,6 +90,10 @@
 {% endblock %}
 
 {% block content %}
+{% if title %}
+<h2>{{ title }}</h2>
+{% else %}
 <h2>Check unknown Gyms</h2>
+{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -8,7 +8,7 @@
 
     <script>
         $(document).ready(function () {
-            $("#navunkown").addClass("active");
+            $("#navunknown").addClass("active");
 
             var displayResources = $('#show-data');
 
@@ -49,6 +49,5 @@
 
 {% block content %}
     <h2>Check unknown Gyms</h2>
-    <h4><a href="/">Back to Menu</a></h4>
     <div id="show-data"></div>
 {% endblock %}

--- a/templates/unknown.html
+++ b/templates/unknown.html
@@ -90,10 +90,6 @@
 {% endblock %}
 
 {% block content %}
-{% if title %}
-<h2>{{ title }}</h2>
-{% else %}
 <h2>Check unknown Gyms</h2>
-{% endif %}
 <table id="show-data" class="table"></table>
 {% endblock %}


### PR DESCRIPTION
Rework the Ui from MADmin

## Description
The Ui is changed to bootstrap and using of datatables is changed.

## Motivation and Context
Better handling of MADmin functions.

## How Has This Been Tested?
Own instance of RD-Map.

## Screenshots (if appropriate):
![grafik](https://user-images.githubusercontent.com/5256612/50045759-0bd4c300-0099-11e9-8a90-99c6c334eb36.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] Where appropriate examples are updated such as config.ini.example
- [ ] I have updated the documentation accordingly.